### PR TITLE
Make limit example a working example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ ./run-jerikan build
 To limit to a few devices:
 
 ```console
-$ ./run-jerikan build --limit=gateway\?.ussfo03.blade-group.net,none
+$ ./run-jerikan build --limit=spine\?.ussfo03.blade-group.net,none
 ```
 
 ## Get the scope of a device


### PR DESCRIPTION
The current `./run-jerikan build
--limit=gateway\?.ussfo03.blade-group.net,none` results in a fairly complicated error message about BGPttH:

```
self = <jerikan.jinja.ErrorExtension object at 0x7fb938300a90>
message = "no BGPttH information (don't generate gateway templates alone)"
caller = <Macro anonymous>

    def _raise(self, message, caller):
        """Execute the {% error %} statement, raising an exception."""
>       raise TemplateRuntimeError(message)
E       jinja2.exceptions.TemplateRuntimeError: no BGPttH information (don't generate gateway templates alone)

caller     = <Macro anonymous>
message    = "no BGPttH information (don't generate gateway templates alone)"
self       = <jerikan.jinja.ErrorExtension object at 0x7fb938300a90>

jerikan/jinja.py:365: TemplateRuntimeError
------------------------------------ Captured log call ------------------------------------
INFO     jerikan.build:build.py:112 build template data.j2 to data.yaml for gateway2.ussfo03.blade-group.net
INFO     jerikan.build:build.py:112 build template linux/interfaces.j2 to network-interfaces for gateway2.ussfo03.blade-group.net
INFO     jerikan.build:build.py:112 build template linux/keepalived.j2 to keepalived.conf for gateway2.ussfo03.blade-group.net
INFO     jerikan.build:build.py:213 skip empty template gateway2.ussfo03.blade-group.net for linux/keepalived.j2
INFO     jerikan.build:build.py:112 build template linux/authorized-keys.j2 to authorized_keys for gateway2.ussfo03.blade-group.net
INFO     jerikan.build:build.py:112 build template linux/nftables-rules-v4.j2 to nftables.conf for gateway2.ussfo03.blade-group.net
INFO     jerikan.build:build.py:112 build template linux/sysctl.conf.j2 to sysctl.conf for gateway2.ussfo03.blade-group.net
INFO     jerikan.build:build.py:112 build template linux/motd.j2 to motd for gateway2.ussfo03.blade-group.net
INFO     jerikan.build:build.py:112 build template linux/dhcp.j2 to dhcpd.conf for gateway2.ussfo03.blade-group.net
INFO     jerikan.build:build.py:112 build template linux/nginx.j2 to nginx.conf for gateway2.ussfo03.blade-group.net
-------------------- generated xml file: /app/jerikan/output/junit.xml --------------------
--------------- generated html file: file:///app/jerikan/output/report.html ---------------
================================= short test summary info =================================
FAILED jerikan/build.py::build[gateway1.ussfo03.blade-group.net] - jinja2.exceptions.Tem...
FAILED jerikan/build.py::build[gateway2.ussfo03.blade-group.net] - jinja2.exceptions.Tem...
```